### PR TITLE
meta: only check for the C++ compiler when needed

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('bragi', 'cpp', default_options: ['cpp_std=c++2a'])
+project('bragi', default_options: ['cpp_std=c++2a'])
 
 bragi_inc = include_directories('include')
 bragi_dep = declare_dependency(include_directories: bragi_inc)
@@ -13,5 +13,6 @@ if get_option('install_headers')
 endif
 
 if get_option('build_tests')
+	add_languages('cpp')
 	subdir('tests')
 endif


### PR DESCRIPTION
This avoids the check when it is unnecessary, as that might be unwanted in some cases. For instance, using `subproject("bragi")` would trigger the check, even if the intent is only to get the dependency to pull in the support headers, where no compiler is necessary. This becomes relevant when building `mlibc-headers`, as that is required for building a cross-gcc, and as such has no cross-gcc available.